### PR TITLE
Add Art-Net plugin

### DIFF
--- a/Firmware/nano_moving_light_modular_v2/main/plugins/wifi/udp_control.h
+++ b/Firmware/nano_moving_light_modular_v2/main/plugins/wifi/udp_control.h
@@ -9,6 +9,10 @@
 #include <WiFiUdp.h>
 #include "discovery_globals.h"
 
+// Forward decl: artnet_upsertPatch is defined in artnet_control.h,
+// which is included after this file in wifi_control.h.
+void artnet_upsertPatch(int fixID, uint16_t universe, uint16_t startAddr);
+
 static WiFiUDP _cmdUDP;
 
 // ── Identify watchdog ─────────────────────────────────────────────
@@ -113,6 +117,13 @@ void udp_handlePacket(const char* data, int len) {
       if (strncmp(cmd, "SETNAME:", 8) == 0) {
         discovery_saveName(cmd + 8);
         Serial.printf("[UDP] Name set to \"%s\"\n", ownName);
+        return;
+      }
+      if (strncmp(cmd, "SETPATCH:", 9) == 0) {
+        int fixID = 0, uni = 0, addr = 1;
+        sscanf(cmd + 9, "%d,%d,%d", &fixID, &uni, &addr);
+        artnet_upsertPatch(fixID, (uint16_t)uni, (uint16_t)addr);
+        Serial.printf("[UDP] SETPATCH: Fix#%d U%d @%d\n", fixID, uni, addr);
         return;
       }
       Serial.printf("[UDP] CMD for us: %s\n", cmd);

--- a/Firmware/nano_moving_light_modular_v2/main/plugins/wifi/wifi_control.h
+++ b/Firmware/nano_moving_light_modular_v2/main/plugins/wifi/wifi_control.h
@@ -15,6 +15,7 @@
 #include "discovery_panel_html.h"
 #include "discovery_globals.h"
 #include "udp_control.h"
+#include "../artnet/artnet_panel_html.h"
 
 #define MAX_CUES         32
 #define MAX_TARGETS      16   // max FixID targets per cue
@@ -76,6 +77,9 @@ void sendJson(int code, const String& json) {
   server.sendHeader("Access-Control-Allow-Origin", "*");
   server.send(code, "application/json", json);
 }
+
+// artnet_control.h needs server + sendJson — include here, not at top
+#include "../artnet/artnet_control.h"
 
 String fixTargetsToJson(const Cue& c) {
   String s = "[";
@@ -363,6 +367,14 @@ void handleSeqStart() {
 void setupRoutes() {
   server.on("/",                                           HTTP_GET,  handleRoot);
   server.on("/plugins/wifi/discovery_panel.html",          HTTP_GET,  handleDiscoveryPanel);
+  server.on("/plugins/artnet/panel.html",    HTTP_GET,  [](){
+    server.sendHeader("Cache-Control","no-cache");
+    server.send_P(200,"text/html", ARTNET_PANEL_HTML);
+  });
+  server.on("/api/artnet/status",      HTTP_GET,  handleArtnetStatus);
+  server.on("/api/artnet/patch",       HTTP_GET,  handleGetArtnetPatch);
+  server.on("/api/artnet/patch/bulk",  HTTP_POST, handleBulkArtnetPatch);
+  server.on("/api/artnet/patch",       HTTP_POST, handlePostArtnetPatch);
   server.on("/api/status",            HTTP_GET,  handleStatus);
   server.on("/api/ports",             HTTP_GET,  handlePorts);
   server.on("/api/connect",           HTTP_POST, handleConnect);
@@ -389,12 +401,15 @@ void setupRoutes() {
       if (path.endsWith("/targets") && server.method()==HTTP_PUT)  { handleUpdateCueTargets(); return; }
       if (server.method()==HTTP_DELETE) { handleDeleteCue(); return; }
     }
+    if (path.startsWith("/api/artnet/patch/") && server.method()==HTTP_DELETE)
+      { handleDeleteArtnetPatch(); return; }
     server.send(404,"text/plain","Not found");
   });
 }
 
 void wifi_control_setup() {
   loadCuesFromFlash();
+  artnet_control_setup();
   Serial.println("[WiFi] IP: " + WiFi.localIP().toString());
   setupRoutes();
   server.begin();

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/wifi_control.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/wifi_control.h
@@ -16,7 +16,6 @@
 #include "discovery_globals.h"
 #include "udp_control.h"
 #include "../artnet/artnet_panel_html.h"
-#include "../artnet/artnet_control.h"
 
 #define MAX_CUES         32
 #define MAX_TARGETS      16   // max FixID targets per cue
@@ -78,6 +77,9 @@ void sendJson(int code, const String& json) {
   server.sendHeader("Access-Control-Allow-Origin", "*");
   server.send(code, "application/json", json);
 }
+
+// artnet_control.h needs server + sendJson — include after they're defined
+#include "../artnet/artnet_control.h"
 
 String fixTargetsToJson(const Cue& c) {
   String s = "[";


### PR DESCRIPTION
artnet_control.h uses `server` and `sendJson()` which are defined mid-file. Moving the include to after those definitions fixes the 'sendJson was not declared in this scope' compile error.

Also add SETPATCH: UDP command handler + artnet_upsertPatch forward declaration to udp_control.h (v2), and apply the same wifi_control.h fix to v3.