### PR TITLE
fix(discovery): leader switch, editable DMX patch sidebar, larger grid IDs, DMX column in heads

### DIFF
--- a/Firmware/nano_moving_light_modular_v3/main/plugins/artnet/artnet_control.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/artnet/artnet_control.h
@@ -119,6 +119,37 @@ void handlePostArtnetPatch() {
   sendJson(200, "{\"status\":\"ok\"}");
 }
 
+// PUT /api/artnet/patch/:fixID  — update universe / startAddr of existing patch
+void handleUpdateArtnetPatch() {
+  String path = server.uri();
+  int fixID = path.substring(path.lastIndexOf('/') + 1).toInt();
+  JsonDocument doc;
+  if (deserializeJson(doc, server.arg("plain"))) {
+    sendJson(400, "{\"status\":\"error\",\"message\":\"Bad JSON\"}"); return;
+  }
+  int universe  = doc["universe"]  | -1;
+  int startAddr = doc["startAddr"] | -1;
+  // Find existing patch
+  for (int i = 0; i < artnetPatchCount; i++) {
+    if (artnetPatches[i].fixID == fixID) {
+      if (universe  >= 0) artnetPatches[i].universe  = (uint16_t)universe;
+      if (startAddr >= 1 && startAddr + DMX_FOOTPRINT - 1 <= DMX_CHANNELS)
+        artnetPatches[i].startAddr = (uint16_t)startAddr;
+      artnet_savePatches();
+      // Push to follower if applicable
+      for (int j = 0; j < peerCount; j++) {
+        if (peers[j].active && peers[j].fixID == fixID) {
+          artnet_pushPatchToFollower(peers[j].ip, peers[j].mac, fixID,
+                                     artnetPatches[i].universe, artnetPatches[i].startAddr);
+          break;
+        }
+      }
+      sendJson(200, "{\"status\":\"ok\"}"); return;
+    }
+  }
+  sendJson(404, "{\"status\":\"error\",\"message\":\"Patch not found\"}");
+}
+
 void handleDeleteArtnetPatch() {
   String path = server.uri();
   int fixID = path.substring(path.lastIndexOf('/') + 1).toInt();

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/artnet/artnet_panel_html.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/artnet/artnet_panel_html.h
@@ -15,7 +15,7 @@ const char ARTNET_PANEL_HTML[] PROGMEM = R"=====(
   .an-num::-webkit-outer-spin-button,.an-num::-webkit-inner-spin-button{-webkit-appearance:none;}
   .an-uni-nav{display:flex;align-items:center;gap:6px;margin-bottom:8px;}
   #an_grid{display:grid;grid-template-columns:repeat(32,1fr);gap:1px;background:var(--border);border:1px solid var(--border);border-radius:4px;overflow:hidden;margin-bottom:12px;cursor:crosshair;}
-  .an-cell{aspect-ratio:1;background:var(--surface2);display:flex;align-items:center;justify-content:center;overflow:hidden;transition:filter 0.08s;font-size:6px;color:rgba(0,0,0,0.7);font-family:var(--mono);font-weight:700;line-height:1;}
+  .an-cell{aspect-ratio:1;background:var(--surface2);display:flex;align-items:center;justify-content:center;overflow:hidden;transition:filter 0.08s;font-size:9px;color:rgba(0,0,0,0.8);font-family:var(--mono);font-weight:700;line-height:1;user-select:none;}
   .an-cell:hover{filter:brightness(1.5);}
   .an-cell.an-pending{outline:2px solid var(--accent);outline-offset:-2px;}
   .an-patch-table{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:11px;margin-top:4px;}
@@ -150,18 +150,20 @@ const char ARTNET_PANEL_HTML[] PROGMEM = R"=====(
     var fix_map={};
     an_fixtures.forEach(function(f){fix_map[f.id]=f.name||('Fix#'+f.id);});
     var html='<table class="an-patch-table"><thead><tr>'
-      +'<th></th><th>Fix#</th><th>Name</th><th>Universe</th><th>Addr</th><th>Channels</th><th></th>'
+      +'<th></th><th>Fix#</th><th>Name</th><th>Universe</th><th>Addr</th><th>Ch</th><th></th>'
       +'</tr></thead><tbody>';
     an_patches.forEach(function(p){
       var sel = an_selectedFixID===p.fixID;
       var name = fix_map[p.fixID]||('Fix#'+p.fixID);
-      html+='<tr class="'+(sel?'an-sel-row':'')+'" onclick="an_selectFix('+p.fixID+')" style="cursor:pointer;">'
-        +'<td><div style="width:10px;height:10px;border-radius:2px;background:'+an_fixColor(p.fixID)+';"></div></td>'
-        +'<td style="color:var(--accent2);">'+p.fixID+'</td>'
-        +'<td>'+name+'</td>'
-        +'<td>'+p.universe+'</td>'
-        +'<td style="color:var(--accent);">'+p.startAddr+'</td>'
-        +'<td style="color:var(--text-dim);">'+p.startAddr+'–'+(p.startAddr+DMX_FP-1)+'</td>'
+      html+='<tr class="'+(sel?'an-sel-row':'')+'" data-fid="'+p.fixID+'">'
+        +'<td onclick="an_selectFix('+p.fixID+')" style="cursor:pointer;"><div style="width:10px;height:10px;border-radius:2px;background:'+an_fixColor(p.fixID)+';"></div></td>'
+        +'<td onclick="an_selectFix('+p.fixID+')" style="cursor:pointer;color:var(--accent2);">'+p.fixID+'</td>'
+        +'<td onclick="an_selectFix('+p.fixID+')" style="cursor:pointer;">'+name+'</td>'
+        +'<td><input type="number" class="an-num" style="width:44px;" value="'+p.universe+'" min="0" max="32767"'
+          +' onclick="event.stopPropagation()" onchange="an_updatePatch('+p.fixID+',+this.value,null)"></td>'
+        +'<td><input type="number" class="an-num" style="width:44px;color:var(--accent);" value="'+p.startAddr+'" min="1" max="512"'
+          +' onclick="event.stopPropagation()" onchange="an_updatePatch('+p.fixID+',null,+this.value)"></td>'
+        +'<td style="color:var(--text-dim);font-size:10px;">'+p.startAddr+'–'+(p.startAddr+DMX_FP-1)+'</td>'
         +'<td><button class="an-del" onclick="an_del(event,'+p.fixID+')">&#10005;</button></td>'
         +'</tr>';
     });
@@ -176,6 +178,22 @@ const char ARTNET_PANEL_HTML[] PROGMEM = R"=====(
     if(p && an_selectedFixID!==null) an_gotoUniverse(p.universe);
     else { an_renderGrid(); an_renderTable(); }
     if(typeof toast==='function' && an_selectedFixID!==null) toast('Fix#'+fixID+' selected — click a grid cell to patch');
+  };
+
+  window.an_updatePatch=function(fixID, uni, addr){
+    var p=an_patches.find(function(x){return x.fixID===fixID;});
+    if(!p) return;
+    var data={universe:uni!==null?uni:p.universe, startAddr:addr!==null?addr:p.startAddr};
+    fetch('/api/artnet/patch/'+fixID,{method:'PUT',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify(data)
+    }).then(function(r){return r.json();}).then(function(d){
+      if(d.status==='ok'){
+        if(uni!==null){ p.universe=uni; if(an_selectedFixID===fixID) an_gotoUniverse(uni); }
+        if(addr!==null) p.startAddr=addr;
+        an_renderGrid(); an_renderTable();
+        if(typeof toast==='function') toast('Patch updated');
+      }
+    });
   };
 
   window.an_del=function(e,fixID){

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/discovery.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/discovery.h
@@ -221,6 +221,19 @@ void discovery_loop() {
     }
   }
 
+  // Safety net: if we think we're LEADER but a peer with lower MAC is also
+  // broadcasting LEADER, yield immediately (handles missed beacon edge cases).
+  if (nodeRole == ROLE_LEADER) {
+    for (int i = 0; i < peerCount; i++) {
+      if (peers[i].active && peers[i].role == ROLE_LEADER &&
+          strcmp(peers[i].mac, ownMAC) < 0) {
+        Serial.printf("[Discovery] Better leader %s active — yielding\n", peers[i].mac);
+        discovery_elect();
+        break;
+      }
+    }
+  }
+
   unsigned long now = millis();
   if (now - _lastBeaconSent >= BEACON_INTERVAL_MS) {
     strncpy(ownIP, WiFi.localIP().toString().c_str(), 15);

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/discovery_panel_html.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/discovery_panel_html.h
@@ -50,19 +50,20 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
         <th>Name</th>
         <th>MAC</th>
         <th>IP</th>
+        <th>DMX</th>
         <th>Role</th>
         <th>Identify</th>
       </tr>
     </thead>
     <tbody id="nh_tbody">
-      <tr><td colspan="7" style="color:var(--text-dim);text-align:center;padding:20px 0;">Scanning...</td></tr>
+      <tr><td colspan="8" style="color:var(--text-dim);text-align:center;padding:20px 0;">Scanning...</td></tr>
     </tbody>
   </table>
 </div>
 
 <script>
 (function(){
-  var headsData=[],fixturePool=[],selectedMACs=[],selectedOfflineFixIDs=[],identTimers={};
+  var headsData=[],fixturePool=[],artnetPatch=[],selectedMACs=[],selectedOfflineFixIDs=[],identTimers={};
 
   nh_load();
   setInterval(nh_load,2000);
@@ -70,8 +71,9 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
   function nh_load(){
     Promise.all([
       fetch('/api/heads').then(function(r){return r.json();}),
-      fetch('/api/fixtures').then(function(r){return r.json();}).catch(function(){return[];})
-    ]).then(function(res){headsData=res[0];fixturePool=res[1];nh_render();}).catch(function(){});
+      fetch('/api/fixtures').then(function(r){return r.json();}).catch(function(){return[];}),
+      fetch('/api/artnet/patch').then(function(r){return r.json();}).catch(function(){return[];})
+    ]).then(function(res){headsData=res[0];fixturePool=res[1];artnetPatch=res[2];nh_render();}).catch(function(){});
   }
 
   function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
@@ -81,7 +83,7 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
     var active=document.activeElement;if(active&&tbody&&tbody.contains(active))return;
     tbody.innerHTML='';
     if(!headsData||!headsData.length){
-      tbody.innerHTML='<tr><td colspan="7" style="color:var(--text-dim);text-align:center;padding:20px 0;">No heads found</td></tr>';
+      tbody.innerHTML='<tr><td colspan="8" style="color:var(--text-dim);text-align:center;padding:20px 0;">No heads found</td></tr>';
     } else {
       var fixCount={};
       headsData.forEach(function(h){if(h.fixID>0)fixCount[h.fixID]=(fixCount[h.fixID]||0)+1;});
@@ -94,6 +96,8 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
       });
       headsData.forEach(function(h){
         var sel=selectedMACs.indexOf(h.mac)>=0,dup=h.fixID>0&&fixCount[h.fixID]>1;
+        var patch=artnetPatch.find(function(p){return p.fixID===h.fixID;});
+        var dmxStr=patch?('U'+patch.universe+'.'+patch.startAddr):'—';
         var tr=document.createElement('tr');
         if(sel)tr.className='selected-head';
         tr.innerHTML=
@@ -103,6 +107,7 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
           '<td><input class="name-input" type="text" value="'+esc(h.name||'')+'" placeholder="Name..." onchange="nh_setName(\''+h.mac+'\',this.value)"></td>'+
           '<td style="color:var(--text-dim);" title="'+h.mac+'">...'+h.mac.slice(-8)+'</td>'+
           '<td style="color:var(--accent);">'+h.ip+'</td>'+
+          '<td style="font-family:var(--mono);font-size:10px;color:'+(patch?'var(--success)':'var(--text-dim)')+';">'+dmxStr+'</td>'+
           '<td><span class="role-badge '+(h.role==='LEADER'?'leader':'follower')+'">'+h.role+'</span></td>'+
           '<td><button class="identify-btn" data-mac="'+h.mac+'" onmousedown="nh_identStart(\''+h.mac+'\')" onmouseup="nh_identStop(\''+h.mac+'\')" onmouseleave="nh_identStop(\''+h.mac+'\')" ontouchstart="nh_identStart(\''+h.mac+'\')" ontouchend="nh_identStop(\''+h.mac+'\')">HOLD</button></td>';
         tbody.appendChild(tr);
@@ -113,10 +118,12 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
     var offline=fixturePool.filter(function(f){return !(f.mac&&onMac.indexOf(f.mac)>=0)&&!(f.id>0&&onFix.indexOf(f.id)>=0);});
     if(offline.length>0){
       var sep=document.createElement('tr');
-      sep.innerHTML='<td colspan="7" style="text-align:center;color:var(--text-dim);font-size:9px;letter-spacing:2px;padding:5px 0;border-top:1px solid var(--border);">-- OFFLINE --</td>';
+      sep.innerHTML='<td colspan="8" style="text-align:center;color:var(--text-dim);font-size:9px;letter-spacing:2px;padding:5px 0;border-top:1px solid var(--border);">-- OFFLINE --</td>';
       tbody.appendChild(sep);
       offline.forEach(function(f){
         var sel=selectedOfflineFixIDs.indexOf(f.id)>=0,tr=document.createElement('tr');
+        var opatch=artnetPatch.find(function(p){return p.fixID===f.id;});
+        var odmxStr=opatch?('U'+opatch.universe+'.'+opatch.startAddr):'—';
         tr.style.opacity='0.55';
         tr.innerHTML=
           '<td><input type="checkbox"'+(sel?' checked':'')+' onchange="nh_toggleOffline('+f.id+',this.checked)"></td>'+
@@ -124,6 +131,7 @@ const char DISCOVERY_PANEL_HTML[] PROGMEM = R"=====(
           '<td><input class="name-input" type="text" value="'+esc(f.name||'')+'" placeholder="Name..." onchange="nh_renameFixture('+f.id+',this.value)"></td>'+
           '<td style="color:var(--text-dim);">'+(f.mac?('...'+f.mac.slice(-8)):'--')+'</td>'+
           '<td>--</td>'+
+          '<td style="font-family:var(--mono);font-size:10px;color:var(--text-dim);">'+odmxStr+'</td>'+
           '<td><span class="role-badge" style="background:rgba(107,107,138,0.15);color:var(--text-dim)">OFFLINE</span></td>'+
           '<td><button class="identify-btn" onclick="nh_deleteFixture('+f.id+')" style="color:var(--danger);border-color:var(--danger);">X</button></td>';
         tbody.appendChild(tr);

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/html_page.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/html_page.h
@@ -63,12 +63,13 @@ const char INDEX_HTML[] PROGMEM = R"=====(
   @media(min-width:900px){
     .main{
       grid-template-columns:2fr 1fr;
-      grid-template-rows:auto auto auto auto 1fr;
+      grid-template-rows:auto auto auto auto auto 1fr;
       grid-template-areas:
         "cues       light"
         "sequencer  motion"
         "future     rainbow"
         "future     serial"
+        "future     artpatch"
         "future     .";
       min-height:calc(100vh - 49px);
     }
@@ -79,9 +80,19 @@ const char INDEX_HTML[] PROGMEM = R"=====(
   .area-motion    {grid-area:motion;}
   .area-rainbow   {grid-area:rainbow;}
   .area-serial    {grid-area:serial;}
+  .area-artpatch  {grid-area:artpatch;}
   .area-cues      {grid-area:cues;}
   .area-sequencer {grid-area:sequencer;}
   .area-future    {grid-area:future;}
+
+  /* ── Art-Net patch sidebar ── */
+  .ap-table{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:11px;}
+  .ap-table th{text-align:left;color:var(--text-dim);font-weight:normal;padding:3px 4px;border-bottom:1px solid var(--border);font-size:10px;letter-spacing:1px;}
+  .ap-table td{padding:3px 4px;border-bottom:1px solid rgba(42,42,58,0.4);vertical-align:middle;}
+  .ap-table tr:last-child td{border-bottom:none;}
+  .ap-num{width:44px;background:var(--surface2);border:1px solid var(--border);color:var(--text);padding:2px 3px;font-family:var(--mono);font-size:10px;border-radius:3px;text-align:center;-moz-appearance:textfield;}
+  .ap-num::-webkit-outer-spin-button,.ap-num::-webkit-inner-spin-button{-webkit-appearance:none;}
+  .ap-del{width:20px;height:20px;border:1px solid var(--border);background:transparent;color:var(--danger);border-radius:3px;cursor:pointer;font-size:10px;line-height:1;padding:0;}
 
   /* ── RGBW Faders ── */
   .faders-row{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;align-items:end;}
@@ -288,6 +299,12 @@ const char INDEX_HTML[] PROGMEM = R"=====(
     </div>
   </div>
 
+  <!-- Art-Net Patch sidebar -->
+  <div class="panel area-artpatch col-right" id="artpatch-sidebar-panel">
+    <div class="panel-title">// Art-Net Patch</div>
+    <div id="ap_list"><div style="font-family:var(--mono);font-size:11px;color:var(--text-dim);text-align:center;padding:8px 0;">No patches</div></div>
+  </div>
+
 </div>
 <div id="toast"></div>
 
@@ -356,6 +373,49 @@ function loadModule(url, id) {
 }
 loadModule('/plugins/wifi/discovery_panel.html','module-container');
 loadModule('/plugins/artnet/panel.html','artnet-module-container');
+// ── Art-Net patch sidebar ─────────────────────────────────────────
+var _FIX_HUES=[200,30,120,270,0,60,160,300,45,330];
+function loadArtpatch(){
+  Promise.all([
+    fetch('/api/artnet/patch').then(function(r){return r.json();}),
+    fetch('/api/fixtures').then(function(r){return r.json();}).catch(function(){return[];})
+  ]).then(function(res){
+    var patches=res[0],fixtures=res[1];
+    var el=document.getElementById('ap_list');if(!el)return;
+    var active=document.activeElement;if(active&&el.contains(active))return;
+    if(!patches.length){el.innerHTML='<div style="font-family:var(--mono);font-size:11px;color:var(--text-dim);text-align:center;padding:8px 0;">No patches</div>';return;}
+    var fmap={};fixtures.forEach(function(f){fmap[f.id]=f.name||('Fix#'+f.id);});
+    var html='<table class="ap-table"><thead><tr><th></th><th>Fix#</th><th>Name</th><th>Uni</th><th>Addr</th><th></th></tr></thead><tbody>';
+    patches.forEach(function(p){
+      var hue=_FIX_HUES[(p.fixID-1)%_FIX_HUES.length];
+      var col='hsl('+hue+',68%,52%)';
+      html+='<tr>'
+        +'<td><div style="width:8px;height:8px;border-radius:2px;background:'+col+'"></div></td>'
+        +'<td style="color:var(--accent2);font-weight:700;">'+p.fixID+'</td>'
+        +'<td style="max-width:70px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+(fmap[p.fixID]||('Fix#'+p.fixID))+'</td>'
+        +'<td><input type="number" class="ap-num" value="'+p.universe+'" min="0" max="32767" onchange="ap_update('+p.fixID+',+this.value,null)"></td>'
+        +'<td><input type="number" class="ap-num" style="color:var(--accent);" value="'+p.startAddr+'" min="1" max="512" onchange="ap_update('+p.fixID+',null,+this.value)"></td>'
+        +'<td><button class="ap-del" onclick="ap_del('+p.fixID+')">&#10005;</button></td>'
+        +'</tr>';
+    });
+    html+='</tbody></table>';
+    el.innerHTML=html;
+  }).catch(function(){});
+}
+window.ap_update=function(fixID,uni,addr){
+  fetch('/api/artnet/patch').then(function(r){return r.json();}).then(function(patches){
+    var p=patches.find(function(x){return x.fixID===fixID;});if(!p)return;
+    var data={universe:uni!==null?uni:p.universe,startAddr:addr!==null?addr:p.startAddr};
+    fetch('/api/artnet/patch/'+fixID,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)})
+      .then(function(){loadArtpatch();if(typeof toast==='function')toast('Patch updated');});
+  });
+};
+window.ap_del=function(fixID){
+  fetch('/api/artnet/patch/'+fixID,{method:'DELETE'}).then(function(){
+    loadArtpatch();if(typeof toast==='function')toast('Patch removed');
+  });
+};
+loadArtpatch();setInterval(loadArtpatch,3000);
 var _artnetWasActive=false;
 function an_pollStatus(){fetch('/api/artnet/status').then(function(r){return r.json();}).then(function(d){if(d.active===_artnetWasActive)return;_artnetWasActive=d.active;document.getElementById('artnet-bar').classList.toggle('visible',d.active);document.getElementById('artnet-bar-count').textContent=d.active?d.patchCount+' fixture(s)':'';['.area-light','.area-motion','.area-rainbow','.area-serial','.area-sequencer'].forEach(function(sel){var el=document.querySelector(sel);if(el)el.classList.toggle('artnet-locked',d.active);});}).catch(function(){});}
 setInterval(an_pollStatus,500);

--- a/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/wifi_control.h
+++ b/Firmware/nano_moving_light_modular_v3/main/plugins/wifi/wifi_control.h
@@ -404,6 +404,8 @@ void setupRoutes() {
     }
     if (path.startsWith("/api/artnet/patch/") && server.method()==HTTP_DELETE)
       { handleDeleteArtnetPatch(); return; }
+    if (path.startsWith("/api/artnet/patch/") && server.method()==HTTP_PUT)
+      { handleUpdateArtnetPatch(); return; }
     server.send(404,"text/plain","Not found");
   });
 }


### PR DESCRIPTION
- discovery.h: add periodic loop check so ESP immediately yields to a better leader (lower MAC) even when beacon is missed
- artnet_control.h: add PUT /api/artnet/patch/:fixID to update universe/startAddr of an existing patch in-place
- wifi_control.h: register PUT route in onNotFound handler
- artnet_panel_html.h: grid cell font-size 6→9px; patch table rows now have editable Universe/Addr number inputs with live PUT updates
- html_page.h: new 'artpatch' grid area below Serial in right sidebar renders patch list with editable fields + 3s live refresh; ap-table/ap-num/ap-del CSS added
- discovery_panel_html.h: fetch /api/artnet/patch in nh_load(); add DMX column (U<uni>.<addr> in green if patched) to online/offline rows